### PR TITLE
Удаление pgadmin за ненадобностью

### DIFF
--- a/audioinfra/docker-compose.yml
+++ b/audioinfra/docker-compose.yml
@@ -15,17 +15,6 @@ services:
       - ..:/app
       - ./sqldocker/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./sqldocker/data:/var/lib/postgresql/data
-  pgadmin:
-    image: dpage/pgadmin4
-    environment:
-      PGADMIN_DEFAULT_EMAIL: pgadmin4@pgadmin.org
-      PGADMIN_DEFAULT_PASSWORD: admin
-    ports:
-      - "5050:80"
-    volumes:
-      - ./pgadmin:/root/.pgadmin
-    depends_on:
-      - sql
   audio:
     build:
       context: ./pydocker


### PR DESCRIPTION
Тянет лишние ресурсы + долго входить в случае рестарта docker compose + постоянно забывает токены и данные для входа