### PR TITLE
Обновление описания хэшей

### DIFF
--- a/audioserver/logic/secactions.py
+++ b/audioserver/logic/secactions.py
@@ -16,8 +16,8 @@ def validate_pass(password):
     return False
 
 def hash_gost_3411(password):
-    """Хэширование пароля по ГОСТ 34.11-2018 (256 бит)"""
-    m = GOST34112012(digest_size=256)
+    """Хэширование пароля по ГОСТ 34.11-2018 (512 бит / 64 байта)"""
+    m = GOST34112012(digest_size=64)
     pass_bytes = str.encode(password)
     m.update(pass_bytes)
 

--- a/main.py
+++ b/main.py
@@ -61,7 +61,7 @@ print('Levenstein distance: ', levenstein_distance)
 print('Original phrase length: ', original_length)
 print('Recognition accuracy: ', recognition_accuracy)
 
-# Пример хэширования пароля по ГОСТ 34.11-2018 "Стрибог"
+# Пример хэширования пароля по ГОСТ 34.11-2012 "Стрибог"
 example_str = "boralekkrutoi123!"
 another_example_str = "boralekochenkrutoi345!!"
 


### PR DESCRIPTION
- в класс передавалось некорректное (но работающее верно) значение - там принимаются байты, т.е. нужно для 512 бит использовать 64 байта, для 256 бит 32 байта
- ГОСТ базовый 34.11-2012, 2018 это международный стандарт (идентичен 2012)