### PR TITLE
Поддержка HTTPS с самоподписанным сертификатом и ключом RSA 4096 бит

### DIFF
--- a/audioinfra/docker-compose.yml
+++ b/audioinfra/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     ports:
       - "50080:50080"
     depends_on:
+      - doctor
       - sql
     volumes:
       - ..:/app

--- a/audioinfra/pydocker/Dockerfile
+++ b/audioinfra/pydocker/Dockerfile
@@ -13,9 +13,13 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt .
 COPY install_pygost.sh .
+COPY ssl.sh .
 RUN apt-get update && apt-get -y install wget=1.21.3-1+b2 --no-install-recommends \
 && apt-get -y install zstd=1.5.4+dfsg2-5 --no-install-recommends \
-&& pip install --no-cache-dir -r requirements.txt && ./install_pygost.sh
+&& apt-get -y install openssl=3.0.11-1~deb12u1 --no-install-recommends \
+&& pip install --no-cache-dir -r requirements.txt \
+&& ./install_pygost.sh \
+&& ./ssl.sh
 
 # Второй этап - копируем .venv из первого и подготавливаем к запуску
 FROM python:3.11-slim
@@ -24,6 +28,10 @@ COPY --from=builder /opt/venv /opt/venv
 
 WORKDIR /app
 
+COPY --from=builder /usr/share/cert.key /usr/share
+COPY --from=builder /usr/share/cert.cer /usr/share
+
 ENV PATH="/opt/venv/bin:$PATH"
 
-ENTRYPOINT ["python", "-m", "uvicorn", "doctor_server:app", "--host", "0.0.0.0", "--port", "48080"]
+ENTRYPOINT ["python", "-m", "uvicorn", "doctor_server:app", "--host", "0.0.0.0", "--port", "48080",\
+            "--ssl-certfile", "/usr/share/cert.cer", "--ssl-keyfile", "/usr/share/cert.key"]

--- a/audioinfra/pydocker/ssl.sh
+++ b/audioinfra/pydocker/ssl.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Данные для выпуска сертификата
+SUBJECT="/C=RU/ST=Tomskaya oblast/L=Tomsk/O=TUSUR/OU=KIBEVS/CN=Tusuraudio"
+
+# Выпуск сертификата
+mkdir -p /usr/share
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out /usr/share/cert.key
+openssl req -new -x509 -days 365 -key /usr/share/cert.key -out /usr/share/cert.cer \
+  -subj "$SUBJECT"

--- a/audioinfra/pydocker_patient/Dockerfile
+++ b/audioinfra/pydocker_patient/Dockerfile
@@ -13,9 +13,13 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt .
 COPY install_pygost.sh .
+COPY ssl.sh .
 RUN apt-get update && apt-get -y install wget=1.21.3-1+b2 --no-install-recommends \
 && apt-get -y install zstd=1.5.4+dfsg2-5 --no-install-recommends \
-&& pip install --no-cache-dir -r requirements.txt && ./install_pygost.sh
+&& apt-get -y install openssl=3.0.11-1~deb12u1 --no-install-recommends \
+&& pip install --no-cache-dir -r requirements.txt \
+&& ./install_pygost.sh \
+&& ./ssl.sh
 
 # Второй этап - копируем .venv из первого и подготавливаем к запуску
 FROM python:3.11-slim
@@ -24,6 +28,10 @@ COPY --from=builder /opt/venv /opt/venv
 
 WORKDIR /app
 
+COPY --from=builder /usr/share/cert.key /usr/share
+COPY --from=builder /usr/share/cert.cer /usr/share
+
 ENV PATH="/opt/venv/bin:$PATH"
 
-ENTRYPOINT ["python", "-m", "uvicorn", "patient_server:app", "--host", "0.0.0.0", "--port", "50080"]
+ENTRYPOINT ["python", "-m", "uvicorn", "patient_server:app", "--host", "0.0.0.0", "--port", "50080",\
+            "--ssl-certfile", "/usr/share/cert.cer", "--ssl-keyfile", "/usr/share/cert.key"]

--- a/audioinfra/pydocker_patient/ssl.sh
+++ b/audioinfra/pydocker_patient/ssl.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Данные для выпуска сертификата
+SUBJECT="/C=RU/ST=Tomskaya oblast/L=Tomsk/O=TUSUR/OU=KIBEVS/CN=Tusuraudio"
+
+# Выпуск сертификата
+mkdir -p /usr/share
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out /usr/share/cert.key
+openssl req -new -x509 -days 365 -key /usr/share/cert.key -out /usr/share/cert.cer \
+  -subj "$SUBJECT"

--- a/audioserver/doctor_server.py
+++ b/audioserver/doctor_server.py
@@ -2,6 +2,7 @@ from enum import Enum
 from fastapi import FastAPI, status, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from logic.tables import (PostPatientInfo, PostSessionInfo, PostSpeechInfo,
                           CompareSessionsIDs, TokenObject, PasswordChangeInfo, LoginInfo)
 from logic.actions import (insert_patient, select_all_patients, select_patient_by_key,
@@ -14,6 +15,9 @@ from logic.actionsauth import (check_token, get_username_from_token, get_uuid_fr
                                create_two_tokens, get_role_from_token)
 
 app = FastAPI()
+
+# Перенаправляем весь трафик на HTTPS
+app.add_middleware(HTTPSRedirectMiddleware)
 
 class ErrorCode(Enum):
     """Типы ошибок"""

--- a/audioserver/patient_server.py
+++ b/audioserver/patient_server.py
@@ -2,6 +2,7 @@ from enum import Enum
 from fastapi import FastAPI, status, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from logic.tables import (PostSpeechInfo, TemporaryPasswordChangePatientInfo, TokenObject,
                           PasswordPatientInfo, PostSessionInfoPatient, PostSessionInfo,
                           PasswordChangePatientInfo)
@@ -13,6 +14,9 @@ from logic.actionsauth import (check_token, get_username_from_token, get_uuid_fr
                                create_two_tokens, get_role_from_token)
 
 app = FastAPI()
+
+# Перенаправляем весь трафик на HTTPS
+app.add_middleware(HTTPSRedirectMiddleware)
 
 class ErrorCode(Enum):
     """Типы ошибок"""


### PR DESCRIPTION
Эксперименты с ГОСТ неудачные, используем RSA для создания сертификата.
Далее uvicorn поддерживает HTTPS по TLS 1.3