### PR TITLE
Улучшения DTW

### DIFF
--- a/audioinfra/pydocker/requirements.txt
+++ b/audioinfra/pydocker/requirements.txt
@@ -16,3 +16,4 @@ pip-audit==2.6.1
 pylint==3.0.0
 pyjwt==2.8.0
 loguru==0.7.2
+dtw-python==1.3.0

--- a/audioinfra/pydocker_patient/requirements.txt
+++ b/audioinfra/pydocker_patient/requirements.txt
@@ -16,3 +16,4 @@ pip-audit==2.6.1
 pylint==3.0.0
 pyjwt==2.8.0
 loguru==0.7.2
+dtw-python==1.3.0

--- a/audioserver/logic/actions.py
+++ b/audioserver/logic/actions.py
@@ -383,11 +383,11 @@ def compare_three_sessions(_, session_1_id: int, session_2_id: int, session_3_id
         speech_values_dict[speech_value_key] = [speech_1_value, speech_2_value, speech_3_value]
         speech_value_key += 1
 
-    # Получение расстояний DTW по формуле сравнения сеанса с 2 эталонами и общей оценки сеанса (среднее)
+    # Получение оценок по формуле сравнения сеанса с 2 эталонами и общей оценки сеанса (среднее)
     dtw_distances = compare_three_sessions_dtw(speech_values_dict)
-    logger.debug(f'Получены расстояния DTW {dtw_distances}')
+    logger.debug(f'Получены оценки {dtw_distances}')
     dtw_mean = statistics.mean(dtw_distances.values())
-    logger.debug(f'Получено среднее значение DTW {dtw_mean}')
+    logger.debug(f'Получена средняя оценка {dtw_mean}')
 
     # Заполнение таблицы сравнения сеансов
     with Session(engine) as session:

--- a/audioserver/logic/actionsaudio.py
+++ b/audioserver/logic/actionsaudio.py
@@ -51,7 +51,7 @@ def compare_two_sessions_dtw(speech_values_dict):
         y2_hilbert = audio_envelopes.hilbert_envelope(y2)
 
         logger.debug('Получаем расстояния между 2 .wav файлами')
-        dtw_distance = audio_metrics.get_audio_dtw(y1_hilbert, y2_hilbert)
+        dtw_distance = audio_metrics.get_dtw_unbound(y1_hilbert, y2_hilbert)
         logger.debug(f'DTW между Ei и R1i: {dtw_distance}')
 
         dtw_distances[key] = dtw_distance
@@ -93,11 +93,11 @@ def compare_three_sessions_dtw(speech_values_dict):
         y3_hilbert = audio_envelopes.hilbert_envelope(y3)
 
         logger.debug('Получаем расстояния между 3 .wav файлами')
-        dtw_distance_12 = audio_metrics.get_audio_dtw(y1_hilbert, y2_hilbert)
+        dtw_distance_12 = audio_metrics.get_dtw_unbound(y1_hilbert, y2_hilbert)
         logger.debug(f'DTW между Ei и R1i: {dtw_distance_12}')
-        dtw_distance_13 = audio_metrics.get_audio_dtw(y1_hilbert, y3_hilbert)
+        dtw_distance_13 = audio_metrics.get_dtw_unbound(y1_hilbert, y3_hilbert)
         logger.debug(f'DTW между Ei и R2i: {dtw_distance_13}')
-        dtw_distance_23 = audio_metrics.get_audio_dtw(y2_hilbert, y3_hilbert)
+        dtw_distance_23 = audio_metrics.get_dtw_unbound(y2_hilbert, y3_hilbert)
         logger.debug(f'DTW между R1i и R2i: {dtw_distance_23}')
 
         logger.debug('Рассчитываем оценку речи по формуле (обычная с 2 эталонами)')

--- a/audioserver/logic/audiometrics/metrics.py
+++ b/audioserver/logic/audiometrics/metrics.py
@@ -1,5 +1,6 @@
 import math
 import numpy as np
+from dtw import dtw
 
 class AudioMetrics:
     """Расчет расстояний между аудиофайлами"""
@@ -78,7 +79,6 @@ class AudioMetrics:
 
         return(start_index_y1, end_index_y1, start_index_y2, end_index_y2)
 
-
     def get_audio_dtw(self, y1, y2):
         """Получение DTW между двумя аудиофайлами (1000 эл.)"""
         start_index_y1, end_index_y1, start_index_y2, end_index_y2 = self.get_boundaries(y1, y2)
@@ -96,3 +96,34 @@ class AudioMetrics:
         start_index_y1, end_index_y1, start_index_y2, end_index_y2 = self.get_boundaries(y1, y2)
         distance = self.edr(y1[start_index_y1:end_index_y1], y2[start_index_y2:end_index_y2],0.001)
         return distance
+
+    def get_dtw_with_indices(self, y1, y2):
+        """Получение DTW между двумя аудиофайлами (вся длина),
+           также рядов с индексами изначальных рядов"""
+        dtw_class = dtw(y1, y2)
+
+        dtw_distance = dtw_class.distance
+        dtw_indices1 = dtw_class.index1
+        dtw_indices2 = dtw_class.index2
+
+        return dtw_distance, dtw_indices1, dtw_indices2
+
+    def get_dtw_unbound(self, y1, y2):
+        """Получение DTW расстояния между двумя аудиофайлами (вся длина)"""
+        dtw_class = dtw(y1, y2)
+
+        dtw_distance = dtw_class.distance
+
+        return dtw_distance
+
+    def get_dtw_transformed_sequences(self, y1, y2):
+        """Получение трансформированных DTW рядов по изначальным"""
+        dtw_class = dtw(y1, y2)
+
+        dtw_indices1 = dtw_class.index1
+        dtw_indices2 = dtw_class.index2
+
+        y1_transformed = [y1[i] for i in dtw_indices1]
+        y2_transformed = [y2[i] for i in dtw_indices2]
+
+        return y1_transformed, y2_transformed

--- a/main.py
+++ b/main.py
@@ -92,3 +92,64 @@ print('Огибающая Гильберта: ', hilbert_envelope)
 
 fft_envelope = AE.fft_envelope(y)
 print('Огибающая FFT: ', fft_envelope)
+
+# Пример использования DTW: получение расстояния и трансформированных последовательностей (одинаковая длина)
+y8, sr8 = AudioFile('8.wav').load()
+y9, sr9 = AudioFile('9.wav').load()
+
+AM = AudioMetrics()
+distance, indices1, indices2 = AM.get_dtw_with_indices(y8, y9)
+
+print('Расстояние DTW: ', distance)
+print('y1: ', y8)
+print('y2: ', y9)
+print('Сопоставляемый ряд y1: ', indices1)
+print('Сопоставляемый ряд y2: ', indices2)
+print('Длина y1: ', len(y8))
+print('Длина y2: ', len(y9))
+print('Длина сопост. y1: ', len(indices1))
+print('Длина сопост. y2: ', len(indices2))
+
+# Пример использования DTW: получение расстояния и индексов трансформированных последовательностей (разная длина)
+y8, sr8 = AudioFile('8.wav').load()
+y9, sr9 = AudioFile('15.wav').load()
+
+AM = AudioMetrics()
+distance, indices1, indices2 = AM.get_dtw_with_indices(y8, y9)
+
+print('Расстояние DTW: ', distance)
+print('y1: ', y8)
+print('y2: ', y9)
+print('Сопоставляемый ряд y1: ', indices1)
+print('Сопоставляемый ряд y2: ', indices2)
+print('Длина y1: ', len(y8))
+print('Длина y2: ', len(y9))
+print('Длина сопост. y1: ', len(indices1))
+print('Длина сопост. y2: ', len(indices2))
+
+# Пример получения расстояния DTW по всей длине последовательности с последовательностями разной длины
+y8, sr8 = AudioFile('8.wav').load()
+y15, sr15 = AudioFile('15.wav').load()
+
+AM = AudioMetrics()
+distance = AM.get_dtw_unbound(y8, y15)
+
+print('Расстояние DTW: ', distance)
+print('Длина y1: ', len(y8))
+print('Длина y2: ', len(y15))
+
+# Пример получения трансформированных DTW последовательностей
+# Тут лучше запускать скрипт через python3 main.py > main.txt (с перенаправлением)
+# т.к. трансформированные ряды не усекаются
+y8, sr8 = AudioFile('8.wav').load()
+y15, sr15 = AudioFile('15.wav').load()
+
+AM = AudioMetrics()
+y1_transformed, y2_transformed = AM.get_dtw_transformed_sequences(y8, y15)
+
+print('Исходный ряд y1: ', y8)
+print('Исходный ряд y2: ', y15)
+print('Трансформированный ряд y1: ', y1_transformed)
+print('Трансформированный ряд y2: ', y2_transformed)
+print('Длины рядов y1, y2: ', len(y8), len(y15))
+print('Длины трансформированных y1, y2: ', len(y1_transformed), len(y2_transformed))


### PR DESCRIPTION
- пример получения трансформированных DTW рядов по индексам сопоставления
- переход на использование DTW из dtw-python (работает по всей длине последовательности + быстрее чем самописная + через нее же можно получить трансформированные ряды)